### PR TITLE
Update windows hiddify link

### DIFF
--- a/src/content/docs/start/reality_app.mdx
+++ b/src/content/docs/start/reality_app.mdx
@@ -41,7 +41,7 @@ description: Выбор прилоений для подключений
 
 ### Hiddify-next
 
-[Hiddify-Next SETUP](https://github.com/hiddify/hiddify-next/releases/latest/download/hiddify-windows-x64-setup.zip)[PORTABLE](https://github.com/hiddify/hiddify-next/releases/latest/download/hiddify-windows-x64-portable.zip)
+[Hiddify-Next](https://github.com/hiddify/hiddify-app/releases)
 
 ### NekoRay
 


### PR DESCRIPTION
The previous link does not work
Apparently the release was deleted

Therefore, I indicated a link to the list of releases, as it was done for nikorai and v2rayN